### PR TITLE
GitHub actions & PR/issues templates implementation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. step 1
+2. step 2
+3. step 3
+...
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Error message**
+If applicable, paste here your error message.
+
+**Runtime information (please complete the following information):**
+ - Node version: [e.g. 12.7]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+**Changes description**
+A clear and concise description of the changes proposed.
+
+**New features**
+If applicable, any new features implemented.
+- feature 1: [...]
+- feature 2: [...]
+
+**Updated features**
+If applicable, description of the updates performed on existing features
+- feature 1: [...]
+- feature 2: [...]
+
+**Related issues**
+Any related issues that have been fixed by this PR.
+
+**Tags**
+Tag any people who should have a look to this PR.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,5 @@ jobs:
       run: npm i
     - name: Test
       run: npm test
+      env:
+        INIT_CLIENT_OPTS: ${{ secrets.INIT_CLIENT_OPTS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: build
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'dev'
+    types: [opened, reopened, edited]
+    paths:
+      - 'index.js'
+      - 'modules/**'
+      - 'test/**'
+      - 'package.json'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
+    - name: Test
+      run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: publish
+on:
+  pull_request:
+    branches:
+      - 'master'
+    types: [closed]
+    paths:
+      - 'index.js'
+      - 'modules/**'
+      - 'package.json'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 10
+    - name: Install dependencies
+      run: npm i
+    - name: Test
+      run: npm test
+    - name: Publish to NPM
+      uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
       run: npm i
     - name: Test
       run: npm test
+      env:
+        INIT_CLIENT_OPTS: ${{ secrets.INIT_CLIENT_OPTS }}
     - name: Publish to NPM
       uses: JS-DevTools/npm-publish@v1
       with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Build badge](https://img.shields.io/github/workflow/status/kaskadi/collmex-client/build?logo=mocha)
+![Publish badge](https://img.shields.io/github/workflow/status/kaskadi/collmex-client/publish?logo=npm)
+
 # collmex-client
 
 A Node client to communicate with Collmex API. This was inspired by our [`co-collmex` package](https://www.npmjs.com/package/co-collmex) but rewritten with modern Javascript (removing deprecated dependencies in the process).

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 const assert = require('chai').assert
 const fs = require('fs')
-const options = fs.existsSync(`${__dirname}/data/options.json`) ? require('./data/options.json') : require('./data/options.default.json')
+const options = fs.existsSync(`${__dirname}/data/options.json`) ? require('./data/options.json') : process.env.INIT_CLIENT_OPTS ? JSON.parse(process.env.INIT_CLIENT_OPTS) : require('./data/options.default.json')
 const invalidOptions = require('./data/options.invalid.json')
 const collmex = require('../index.js')(options)
 const invalidCollmex = require('../index.js')(invalidOptions)


### PR DESCRIPTION
**Changes description**
Implemented GitHub actions (`publish` and `build`) & PR/issues templates.

**Updated features**
- _tests:_ added support for client init options loading from environment variables when running in GitHub Actions

**New features**
- _build action:_ action to run `npm test`. Triggers on any PR for `master` and `dev` when the PR is `opened`, `reopened` or `edited`
- _publish action:_ action to publish to NPM. Triggers when a PR for `master` is closed. Also runs `npm test` before publishing
- _PR/issues templates:_ added templates for PR and issues

**Notes**
Next step: work on scrapper for `satzarten.json`