### PR TITLE
Publish action trigger update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: publish
 on:
-  pull_request:
+  push:
     branches:
       - 'master'
-    types: [closed]
     paths:
       - 'index.js'
       - 'modules/**'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Build badge](https://img.shields.io/github/workflow/status/kaskadi/collmex-client/build?logo=mocha)
-![Publish badge](https://img.shields.io/github/workflow/status/kaskadi/collmex-client/publish?logo=npm)
+![Build badge](https://img.shields.io/github/workflow/status/kaskadi/collmex-client/build?label=build&logo=mocha)
+![Publish badge](https://img.shields.io/github/workflow/status/kaskadi/collmex-client/publish?label=publish&logo=npm)
 
 # collmex-client
 


### PR DESCRIPTION
**Changes description**
Switched to `push` as trigger for `publish` action. This fixes behavior where the workflow would run on PR close event (w/o merge) and allows for publishing when a hotfix is pushed to `master`.
Also fixed badges.

**Updated features**
- _publish action:_ switched from `pull_request` with `types` `[closed]` to `push` as action trigger.
- _badges:_ fixed badges to display proper workflow name