### PR TITLE
Implemented utility to compare local/remote versions

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -22,6 +22,8 @@ A Node client to communicate with Collmex API. This was inspired by our [`co-col
 
 **Note:** this package uses a GitHub Action `sync-data` (see [here](https://github.com/kaskadi/collmex-client/actions?query=workflow%3Async-data) and [there](./.github/workflows/sync-data.yml)) to scrap Collmex API documentation daily to check that the CSV mapping (stored [here](./data/satzarten.json)) used is still up to date. This mapping could have been stored into a public CDN and fetched on client instanciation (& then on daily basis for persistent clients) but that would slow down performances and introduce a potential failure point (CDN down -> no data). **Please make sure you always use the latest version of this package to ensure the answer you get from Collmex API is the correct one.**
 
+**New in 1.14.0:** when instanciating a new client, a check will be performed to compare your locally installed version of `collmex-client` with the latest one available on `npm`. If the version you use is not the latest one, a warning will be printed in `stdout`.
+
 {{>main}}
 
 # Details

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const checkVersion = require('./modules/check-version.js')
  */
 
 class Collmex {
-  constructor (opts) {
+  constructor (opts = {}) {
     this.User = opts.User || 'noname'
     this.Password = opts.Password || 'password'
     this.CMXKundennummer = opts.CMXKundennummer || '112233'

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const getCollmexData = require('./modules/get-collmex-data.js')
 const parseCSV = require('csv-parse/lib/sync')
 const sanitizeData = require('./modules/sanitize-data.js')
 const parseData = require('./modules/parse-data.js')
+const checkVersion = require('./modules/check-version.js')
 
 /**
  * Options for the new Collmex client instanciation
@@ -42,6 +43,7 @@ class Collmex {
     this.Firma_Nr = opts.Firma_Nr || 1
     this.Systemname = opts.Systemname || 'collmex-client'
     this.Output = opts.Output || 'object'
+    checkVersion()
   }
 
   /**

--- a/modules/check-version.js
+++ b/modules/check-version.js
@@ -5,7 +5,6 @@ const { spawnSync } = require('child_process')
 module.exports = () => {
   const pjson = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
   const pkgName = pjson.name
-  console.log(`INFO: comparing locally installed version of ${pkgName} to latest available on npm...`)
   const localVer = pjson.version
   const npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
   const remoteVer = npmData.version

--- a/modules/check-version.js
+++ b/modules/check-version.js
@@ -1,0 +1,22 @@
+const { readFileSync } = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+module.exports = () => {
+  const pjson = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
+  const pkgName = pjson.name
+  console.log(`INFO: comparing locally installed version of ${pkgName} to latest available on npm...`)
+  const localVer = pjson.version
+  const npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
+  const remoteVer = npmData.version
+  if (checkSum(localVer) < checkSum(remoteVer)) {
+    console.log(`WARNING: your local version of ${pkgName} is ${localVer} while the latest available version on npm is ${remoteVer}. Please consider updating your client as you may be using outdated CSV mapping...`)
+  }
+}
+
+function checkSum (ver) {
+  // here we do a weighted check sum where major version has a weight of 100, minor has 10 and patch has 1. We disregard the beta/alpha flags as we probably won't be using them
+  return ver
+    .split('.')
+    .reduce((acc, cur, i) => acc + (10 ** (2 - i)) * cur, 0)
+}

--- a/modules/check-version.js
+++ b/modules/check-version.js
@@ -9,7 +9,7 @@ module.exports = () => {
   const npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
   const remoteVer = npmData.version
   if (checkSum(localVer) < checkSum(remoteVer)) {
-    console.log(`WARNING: your local version of ${pkgName} is ${localVer} while the latest available version on npm is ${remoteVer}. Please consider updating your client as you may be using outdated CSV mapping...`)
+    console.log(`WARNING: your local version of ${pkgName} is ${localVer} while the latest available version on npm is ${remoteVer}. Please consider updating your client as you may be using an outdated CSV mapping...`)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "collmex-client",
-  "version": "1.13.10",
+  "version": "1.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -378,6 +378,16 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "argle": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/argle/-/argle-1.1.1.tgz",
+      "integrity": "sha1-DP47wDLDay9IukK5wX+J9wYH6ZQ=",
+      "dev": true,
+      "requires": {
+        "lodash.isfunction": "^3.0.8",
+        "lodash.isnumber": "^3.0.3"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -397,6 +407,12 @@
         "es-abstract": "^1.17.0",
         "is-string": "^1.0.5"
       }
+    },
+    "array-uniq": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=",
+      "dev": true
     },
     "array.prototype.map": {
       "version": "1.0.2",
@@ -482,6 +498,17 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "capture-console": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-console/-/capture-console-1.0.1.tgz",
+      "integrity": "sha1-22PDmscyOQGbrdf7sQFD7aOA/3E=",
+      "dev": true,
+      "requires": {
+        "argle": "~1.1.1",
+        "lodash.isfunction": "~3.0.8",
+        "randomstring": "~1.1.5"
+      }
     },
     "chai": {
       "version": "4.2.0",
@@ -2079,6 +2106,18 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -2826,6 +2865,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomstring": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.1.5.tgz",
+      "integrity": "sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.2"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
+    "capture-console": "^1.0.1",
     "chai": "^4.2.0",
     "mocha": "^8.1.1",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collmex-client",
-  "version": "1.13.10",
+  "version": "1.14.0",
   "description": "a node client to communicate with Collmex API.",
   "main": "index.js",
   "scripts": {

--- a/test/check-version.test.js
+++ b/test/check-version.test.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+const assert = require('chai').assert
+const capcon = require('capture-console')
+const pjson = require('../package.json')
+const originalVersion = pjson.version
+const { writeFileSync } = require('fs')
+
+describe('collmex-client check version utility', function () {
+  it('should warn if version is behind on patches', function () {
+    updatePjsonVersion(getWrongVersion(originalVersion, 2))
+    test(true)
+  })
+  it('should warn if version is behind on minors', function () {
+    updatePjsonVersion(getWrongVersion(originalVersion, 1))
+    test(true)
+  })
+  it('should warn if version is behind on majors', function () {
+    updatePjsonVersion(getWrongVersion(originalVersion, 0))
+    test(true)
+  })
+  it('should not warn if version is latest', function () {
+    updatePjsonVersion(originalVersion)
+    test(false)
+  })
+  after(function () {
+    writeFileSync(`${process.cwd()}/package.json`, JSON.stringify(pjson, null, 2), 'utf8')
+  })
+})
+
+function getWrongVersion (originalVersion, i) {
+  const versions = originalVersion.split('.').map(Number)
+  return [...versions.slice(0, i), versions[i] - 1, ...versions.slice(i + 1)]
+    .map(String)
+    .join('.')
+}
+
+function updatePjsonVersion (version) {
+  const newPjson = { ...pjson, version }
+  writeFileSync(`${process.cwd()}/package.json`, JSON.stringify(newPjson, null, 2), 'utf8')
+}
+
+function test (warningFound) {
+  const stdout = capcon.captureStdout(function () {
+    require('../')()
+  })
+  const lines = stdout.split('\n')
+  const warningLine = lines.filter(line => line.startsWith('WARNING: your local version'))
+  assert.equal(warningLine.length === 1, warningFound)
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,10 +3,14 @@ const assert = require('chai').assert
 const fs = require('fs')
 const options = fs.existsSync(`${__dirname}/data/options.json`) ? require('./data/options.json') : process.env.INIT_CLIENT_OPTS ? JSON.parse(process.env.INIT_CLIENT_OPTS) : require('./data/options.default.json')
 const invalidOptions = require('./data/options.invalid.json')
-const collmex = require('../index.js')(options)
-const invalidCollmex = require('../index.js')(invalidOptions)
+const noOptsCollmex = require('../')()
+const collmex = require('../')(options)
+const invalidCollmex = require('../')(invalidOptions)
 
 describe('collmex-client', function () {
+  it('should have default options when no options are specified', function () {
+    testOptions(noOptsCollmex)
+  })
   it('should be able to get product data from collmex as array', async function () {
     await collmex.get([{ Satzart: 'PRODUCT_GET', Produktnummer: options.Produktnummer }], 'array').then(testDataType('array'))
   })
@@ -85,6 +89,16 @@ describe('collmex-client', function () {
     await collmex.get({ Satzart: 'BILL_OF_MATERIAL_GET' }).then(testResponseFields('CMXBOM'))
   })
 })
+
+function testOptions (client) {
+  const { User, Password, CMXKundennummer, Systemname, Output } = client
+  assert.equal(User, 'noname')
+  assert.equal(Password, 'password')
+  assert.equal(CMXKundennummer, '112233')
+  assert.equal(client.Firma_Nr, '1')
+  assert.equal(Systemname, 'collmex-client')
+  assert.equal(Output, 'object')
+}
 
 function testDataType (format) {
   return res => {


### PR DESCRIPTION
**Changes description**
Implemented `check-version` utility that compares local and remote version of the client to ensure we are using the latest CSV mapping. This utility runs on client instantiation.

**New features**
- _`check-version`:_ this utility compares the locally installed version of `collmex-client` with the latest one available on npm. If the local version is not the latest, a warning will be printed.

**Updated features**
- _tests:_ updated tests to include test for missing options and `check-version` utility