### PR TITLE
fix version check for windows systems, fix property overwriting in "satzarten"

### DIFF
--- a/modules/check-version.js
+++ b/modules/check-version.js
@@ -6,7 +6,12 @@ module.exports = () => {
   const pjson = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
   const pkgName = pjson.name
   const localVer = pjson.version
-  const npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
+  let npmData
+  if (process.platform === 'win32') {
+    npmData = JSON.parse(spawnSync('npm.cmd', ['view', pkgName, '--json']).stdout.toString())
+  } else {
+    npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
+  }
   const remoteVer = npmData.version
   if (checkSum(localVer) < checkSum(remoteVer)) {
     console.log(`WARNING: your local version of ${pkgName} is ${localVer} while the latest available version on npm is ${remoteVer}. Please consider updating your client as you may be using an outdated CSV mapping...`)

--- a/modules/get-collmex-data.js
+++ b/modules/get-collmex-data.js
@@ -9,7 +9,7 @@ module.exports = function (opts) {
 function getRequestBody (opts) {
   const satzarten = require('./load-satzarten.js')()
   return opts.reduce((req, opt) => {
-    const satz = satzarten[opt.Satzart]
+    const satz = JSON.parse(JSON.stringify(satzarten))[opt.Satzart]
     for (const prop in opt) {
       satz[prop] = opt[prop]
     }


### PR DESCRIPTION
**Changes description**

- fix an issue wheare an earlier line could add properties to following line in get().
- fix an issue where checkVersion() would run into an error on Windows due to a faulty command that throws an error wich wasn't handled.



**Related issues**
#20
